### PR TITLE
feat: Indent and line-break generated XML

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,13 +1,5 @@
 import { toKML } from '../lib/index';
 
-// test("hexToKmlColor", (t) => {
-//   expect(hexToKmlColor("123", 1), "ff332211");
-//   expect(hexToKmlColor("123", 0.5), "7f332211");
-//   expect(hexToKmlColor("123", 0.05), "0c332211");
-//   expect(hexToKmlColor("aaccdd", 1), "ffddccaa");
-//   t.end();
-// });
-
 describe('toKML', () => {
   it('#toKML', () => {
     expect(
@@ -19,16 +11,19 @@ describe('toKML', () => {
             properties: {
               foo: 'bar',
             },
+
             geometry: {
               type: 'Point',
               coordinates: [0, 2],
             },
           },
+
           {
             type: 'Feature',
             properties: {
               foo: 'bar',
             },
+
             geometry: {
               type: 'MultiPoint',
               coordinates: [
@@ -37,11 +32,13 @@ describe('toKML', () => {
               ],
             },
           },
+
           {
             type: 'Feature',
             properties: {
               foo: 'bar',
             },
+
             geometry: {
               type: 'LineString',
               coordinates: [
@@ -52,9 +49,24 @@ describe('toKML', () => {
           },
         ],
       })
-    ).toEqual(
-      `<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark><ExtendedData><Data name=\"foo\"><value>bar</value></Data></ExtendedData><Point><coordinates>0,2</coordinates></Point></Placemark><Placemark><ExtendedData><Data name=\"foo\"><value>bar</value></Data></ExtendedData><MultiGeometry><Point><coordinates>0,2</coordinates></Point><Point><coordinates>1,2</coordinates></Point></MultiGeometry></Placemark><Placemark><ExtendedData><Data name=\"foo\"><value>bar</value></Data></ExtendedData><LineString><coordinates>0,2\n1,2</coordinates></LineString></Placemark></Document></kml>`
-    );
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+      <ExtendedData>
+        <Data name=\\"foo\\"><value>bar</value></Data></ExtendedData>
+        <Point><coordinates>0,2</coordinates></Point></Placemark>
+      <Placemark>
+      <ExtendedData>
+        <Data name=\\"foo\\"><value>bar</value></Data></ExtendedData>
+        <MultiGeometry>
+      <Point><coordinates>0,2</coordinates></Point>
+      <Point><coordinates>1,2</coordinates></Point></MultiGeometry></Placemark>
+      <Placemark>
+      <ExtendedData>
+        <Data name=\\"foo\\"><value>bar</value></Data></ExtendedData>
+        <LineString><coordinates>0,2
+      1,2</coordinates></LineString></Placemark></Document></kml>"
+    `);
 
     expect(
       toKML({
@@ -65,6 +77,7 @@ describe('toKML', () => {
             properties: {
               foo: 'bar',
             },
+
             geometry: {
               type: 'Polygon',
               coordinates: [
@@ -74,6 +87,7 @@ describe('toKML', () => {
                   [2, 2],
                   [0, 2],
                 ],
+
                 [
                   [0, 3],
                   [1, 3],
@@ -85,9 +99,23 @@ describe('toKML', () => {
           },
         ],
       })
-    ).toEqual(
-      `<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark><ExtendedData><Data name=\"foo\"><value>bar</value></Data></ExtendedData><Polygon><outerBoundaryIs><LinearRing><coordinates>0,2\n1,2\n2,2\n0,2</coordinates></LinearRing></outerBoundaryIs><innerBoundaryIs><LinearRing><coordinates>0,3\n1,3\n2,3\n0,3</coordinates></LinearRing></innerBoundaryIs></Polygon></Placemark></Document></kml>`
-    );
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+      <ExtendedData>
+        <Data name=\\"foo\\"><value>bar</value></Data></ExtendedData>
+        <Polygon>
+      <outerBoundaryIs>
+        <LinearRing><coordinates>0,2
+      1,2
+      2,2
+      0,2</coordinates></LinearRing></outerBoundaryIs>
+      <innerBoundaryIs>
+        <LinearRing><coordinates>0,3
+      1,3
+      2,3
+      0,3</coordinates></LinearRing></innerBoundaryIs></Polygon></Placemark></Document></kml>"
+    `);
 
     expect(
       toKML({
@@ -98,6 +126,7 @@ describe('toKML', () => {
             properties: {
               foo: 'bar',
             },
+
             geometry: {
               type: 'MultiLineString',
               coordinates: [
@@ -107,6 +136,7 @@ describe('toKML', () => {
                   [2, 2],
                   [0, 2],
                 ],
+
                 [
                   [0, 3],
                   [1, 3],
@@ -118,9 +148,21 @@ describe('toKML', () => {
           },
         ],
       })
-    ).toEqual(
-      `<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark><ExtendedData><Data name=\"foo\"><value>bar</value></Data></ExtendedData><MultiGeometry><LineString><coordinates>0,2\n1,2\n2,2\n0,2</coordinates></LineString><LineString><coordinates>0,3\n1,3\n2,3\n0,3</coordinates></LineString></MultiGeometry></Placemark></Document></kml>`
-    );
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+      <ExtendedData>
+        <Data name=\\"foo\\"><value>bar</value></Data></ExtendedData>
+        <MultiGeometry>
+      <LineString><coordinates>0,2
+      1,2
+      2,2
+      0,2</coordinates></LineString>
+      <LineString><coordinates>0,3
+      1,3
+      2,3
+      0,3</coordinates></LineString></MultiGeometry></Placemark></Document></kml>"
+    `);
 
     expect(
       toKML({
@@ -131,6 +173,7 @@ describe('toKML', () => {
             properties: {
               foo: 'bar',
             },
+
             geometry: {
               type: 'MultiPolygon',
               coordinates: [
@@ -141,6 +184,7 @@ describe('toKML', () => {
                     [2, 2],
                     [0, 2],
                   ],
+
                   [
                     [0, 3],
                     [1, 3],
@@ -153,9 +197,24 @@ describe('toKML', () => {
           },
         ],
       })
-    ).toEqual(
-      `<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark><ExtendedData><Data name=\"foo\"><value>bar</value></Data></ExtendedData><MultiGeometry><Polygon><outerBoundaryIs><LinearRing><coordinates>0,2\n1,2\n2,2\n0,2</coordinates></LinearRing></outerBoundaryIs><innerBoundaryIs><LinearRing><coordinates>0,3\n1,3\n2,3\n0,3</coordinates></LinearRing></innerBoundaryIs></Polygon></MultiGeometry></Placemark></Document></kml>`
-    );
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+      <ExtendedData>
+        <Data name=\\"foo\\"><value>bar</value></Data></ExtendedData>
+        <MultiGeometry>
+      <Polygon>
+      <outerBoundaryIs>
+        <LinearRing><coordinates>0,2
+      1,2
+      2,2
+      0,2</coordinates></LinearRing></outerBoundaryIs>
+      <innerBoundaryIs>
+        <LinearRing><coordinates>0,3
+      1,3
+      2,3
+      0,3</coordinates></LinearRing></innerBoundaryIs></Polygon></MultiGeometry></Placemark></Document></kml>"
+    `);
 
     expect(
       toKML({
@@ -168,6 +227,7 @@ describe('toKML', () => {
               bar: { x: 1 },
               q: 1,
             },
+
             geometry: {
               type: 'GeometryCollection',
               geometries: [{ type: 'Point', coordinates: [0, 1] }],
@@ -175,9 +235,16 @@ describe('toKML', () => {
           },
         ],
       })
-    ).toEqual(
-      `<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark><ExtendedData><Data name=\"foo\"><value>bar</value></Data><Data name=\"bar\"><value>{\"x\":1}</value></Data><Data name=\"q\"><value>1</value></Data></ExtendedData><MultiGeometry><Point><coordinates>0,1</coordinates></Point></MultiGeometry></Placemark></Document></kml>`
-    );
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+      <ExtendedData>
+        <Data name=\\"foo\\"><value>bar</value></Data>
+        <Data name=\\"bar\\"><value>{\\"x\\":1}</value></Data>
+        <Data name=\\"q\\"><value>1</value></Data></ExtendedData>
+        <MultiGeometry>
+      <Point><coordinates>0,1</coordinates></Point></MultiGeometry></Placemark></Document></kml>"
+    `);
 
     expect(
       toKML({
@@ -190,9 +257,12 @@ describe('toKML', () => {
           },
         ],
       })
-    ).toEqual(
-      `<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark><Point><coordinates>0,1</coordinates></Point></Placemark></Document></kml>`
-    );
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+
+        <Point><coordinates>0,1</coordinates></Point></Placemark></Document></kml>"
+    `);
 
     expect(
       toKML({
@@ -203,13 +273,17 @@ describe('toKML', () => {
             properties: {
               description: 'test',
             },
+
             geometry: { type: 'Point', coordinates: [0, 1] },
           },
         ],
       })
-    ).toEqual(
-      `<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark><description>test</description><ExtendedData></ExtendedData><Point><coordinates>0,1</coordinates></Point></Placemark></Document></kml>`
-    );
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+      <description>test</description><ExtendedData></ExtendedData>
+        <Point><coordinates>0,1</coordinates></Point></Placemark></Document></kml>"
+    `);
 
     expect(
       toKML({
@@ -220,13 +294,17 @@ describe('toKML', () => {
             properties: {
               name: 'bar',
             },
+
             geometry: null,
           },
         ],
       })
-    ).toEqual(
-      `<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark><name>bar</name><ExtendedData></ExtendedData></Placemark></Document></kml>`
-    );
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+      <name>bar</name><ExtendedData></ExtendedData>
+        </Placemark></Document></kml>"
+    `);
 
     expect(
       toKML({
@@ -237,13 +315,17 @@ describe('toKML', () => {
             properties: {
               name: 'bar',
             },
+
             geometry: { type: 'Point', coordinates: [0, 1] },
           },
         ],
       })
-    ).toEqual(
-      `<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark><name>bar</name><ExtendedData></ExtendedData><Point><coordinates>0,1</coordinates></Point></Placemark></Document></kml>`
-    );
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+      <name>bar</name><ExtendedData></ExtendedData>
+        <Point><coordinates>0,1</coordinates></Point></Placemark></Document></kml>"
+    `);
   });
 
   it('ignores coordinates past #2', () => {
@@ -256,12 +338,16 @@ describe('toKML', () => {
             properties: {
               name: 'bar',
             },
+
             geometry: { type: 'Point', coordinates: [0, 1, 2] },
           },
         ],
       })
-    ).toEqual(
-      `<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark><name>bar</name><ExtendedData></ExtendedData><Point><coordinates>0,1</coordinates></Point></Placemark></Document></kml>`
-    );
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+      <name>bar</name><ExtendedData></ExtendedData>
+        <Point><coordinates>0,1</coordinates></Point></Placemark></Document></kml>"
+    `);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2018",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "ESNext",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Mainly a quality-of-life improvement, this:

- Adds indentation and linebreaks to output
- Uses `matchInlineSnapshot` to make tests easier to update.