### PR TITLE
Support folders export

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,11 +1,35 @@
 import { u } from 'unist-builder';
 import { x } from 'xastscript';
 import type { Element } from 'xast';
+import type { Root, Folder } from '@tmcw/togeojson';
 import type { Feature, FeatureCollection, Geometry, Position } from 'geojson';
 import { toXml } from 'xast-util-to-xml';
 
+type F = Feature<Geometry | null>;
+
 const BR = u('text', '\n');
 const TAB = u('text', '  ');
+
+type Literal = typeof BR;
+
+/**
+ * Convert a GeoJSON FeatureCollection to a string of
+ * KML data.
+ */
+export function foldersToKML(root: Root): string {
+  return toXml(
+    u('root', [
+      x(
+        'kml',
+        { xmlns: 'http://www.opengis.net/kml/2.2' },
+        x(
+          'Document',
+          root.children.flatMap((child) => convertChild(child))
+        )
+      ),
+    ])
+  );
+}
 
 /**
  * Convert a GeoJSON FeatureCollection to a string of
@@ -30,7 +54,44 @@ export function toKML(
   );
 }
 
-function convertFeature(feature: Feature<Geometry | null>) {
+function convertChild(child: F | Folder) {
+  switch (child.type) {
+    case 'Feature':
+      return convertFeature(child);
+    case 'folder':
+      return convertFolder(child);
+  }
+}
+
+function convertFolder(folder: Folder): Array<Literal | Element> {
+  return [
+    BR,
+    x('Folder', [
+      BR,
+      ...folderMeta(folder.meta),
+      BR,
+      TAB,
+      ...folder.children.flatMap((child) => convertChild(child)),
+    ]),
+  ];
+}
+
+const META_PROPERTIES: Array<keyof Folder['meta']> = [
+  'address',
+  'description',
+  'name',
+  'open',
+  'visibility',
+  'phoneNumber',
+];
+
+function folderMeta(meta: Folder['meta']): Element[] {
+  return META_PROPERTIES.filter((p) => meta[p] !== undefined).map((p) => {
+    return x(p, [u('text', String(meta[p]))]);
+  });
+}
+
+function convertFeature(feature: F) {
   return [
     BR,
     x('Placemark', [

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@rollup/plugin-typescript": "^8.3.1",
     "@swc/core": "^1.2.114",
     "@swc/jest": "^0.2.11",
+    "@tmcw/togeojson": "5.0.0-3",
     "@types/geojson": "^7946.0.8",
     "@types/jest": "^27.0.3",
     "eslint": "^8.3.0",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,115 @@
-import { toKML } from '../lib/index';
+import { toKML, foldersToKML } from '../lib/index';
+
+describe('foldersToKML', () => {
+  it('#foldersToKML', () => {
+    expect(
+      foldersToKML({
+        type: 'root',
+        children: [
+          {
+            type: 'Feature',
+            properties: {
+              foo: 'bar',
+            },
+
+            geometry: {
+              type: 'Point',
+              coordinates: [0, 2],
+            },
+          },
+
+          {
+            type: 'folder',
+            meta: { name: 'Hi' },
+            children: [],
+          },
+
+          {
+            type: 'folder',
+            meta: { name: 'Hi' },
+            children: [
+              {
+                type: 'Feature',
+                properties: {
+                  foo: 'bar',
+                },
+
+                geometry: {
+                  type: 'LineString',
+                  coordinates: [
+                    [0, 2],
+                    [1, 2],
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      })
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+      <ExtendedData>
+        <Data name=\\"foo\\"><value>bar</value></Data></ExtendedData>
+        <Point><coordinates>0,2</coordinates></Point></Placemark>
+      <Folder>
+      <name>Hi</name>
+        </Folder>
+      <Folder>
+      <name>Hi</name>
+        
+      <Placemark>
+      <ExtendedData>
+        <Data name=\\"foo\\"><value>bar</value></Data></ExtendedData>
+        <LineString><coordinates>0,2
+      1,2</coordinates></LineString></Placemark></Folder></Document></kml>"
+    `);
+    expect(
+      foldersToKML({
+        type: 'root',
+        children: [
+          {
+            type: 'Feature',
+            properties: {
+              foo: 'bar',
+            },
+
+            geometry: {
+              type: 'Point',
+              coordinates: [0, 2],
+            },
+          },
+
+          {
+            type: 'Feature',
+            properties: {
+              foo: 'bar',
+            },
+
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [0, 2],
+                [1, 2],
+              ],
+            },
+          },
+        ],
+      })
+    ).toMatchInlineSnapshot(`
+      "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+      <Placemark>
+      <ExtendedData>
+        <Data name=\\"foo\\"><value>bar</value></Data></ExtendedData>
+        <Point><coordinates>0,2</coordinates></Point></Placemark>
+      <Placemark>
+      <ExtendedData>
+        <Data name=\\"foo\\"><value>bar</value></Data></ExtendedData>
+        <LineString><coordinates>0,2
+      1,2</coordinates></LineString></Placemark></Document></kml>"
+    `);
+  });
+});
 
 describe('toKML', () => {
   it('#toKML', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,6 +666,11 @@
   dependencies:
     "@jest/create-cache-key-function" "^27.4.2"
 
+"@tmcw/togeojson@5.0.0-3":
+  version "5.0.0-3"
+  resolved "https://registry.yarnpkg.com/@tmcw/togeojson/-/togeojson-5.0.0-3.tgz#3da7415e0a948e7a99251d6bfc1b445edb19aaac"
+  integrity sha512-STMt6EcGbwqxEpas2xgg0Ww056xnCxFnUNvU/Fa4/see9ot+NLA/qCzVl+wXJwXjH7rnSaoMv8zK9w/u5umvKA==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
- Fixes #12

This adds a `foldersToKML` method that exports the 'Root' format generated by toGeoJSON.