### PR TITLE
feat: Ground overlay

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -98,8 +98,41 @@ function folderMeta(meta: Folder['meta']): Element[] {
   });
 }
 
+function convertGroundOverlay(feature: F) {
+  const { id } = feature;
+
+  const idMember = ['string', 'number'].includes(typeof id)
+    ? {
+        id: id,
+      }
+    : {};
+  return [
+    BR,
+    x('GroundOverlay', idMember, [
+      BR,
+      ...propertiesToTags(feature.properties),
+      BR,
+      TAB,
+      ...(feature.geometry
+        ? [
+            x(
+              'gx:LatLonQuad',
+              [],
+              [u('text', feature.geometry.coordinates[0].map(join).join('\n'))]
+            ),
+          ]
+        : []),
+    ]),
+  ];
+}
+
 function convertFeature(feature: F) {
   const { id } = feature;
+
+  if (feature.properties?.['@geometry-type'] === 'groundoverlay') {
+    return convertGroundOverlay(feature);
+  }
+
   const idMember = ['string', 'number'].includes(typeof id)
     ? {
         id: id,
@@ -166,11 +199,13 @@ function maybeCData(value: any) {
 
 function propertiesToTags(properties: Feature['properties']): Element[] {
   if (!properties) return [];
-  const { name, description, visibility, ...otherProperties } = properties;
+  const { name, description, visibility, icon, ...otherProperties } =
+    properties;
 
   return [
     name && x('name', [u('text', toString(name))]),
     description && x('description', [u('text', maybeCData(description))]),
+    icon && x('icon', [u('text', maybeCData(icon))]),
     visibility !== undefined &&
       x('visibility', [u('text', visibility ? '1' : '0')]),
     x(

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@rollup/plugin-typescript": "^9.0.2",
     "@tmcw/togeojson": "5.4.0",
     "@types/geojson": "^7946.0.8",
+    "@xmldom/xmldom": "^0.8.5",
     "eslint": "^8.18.0",
     "prettier": "^2.7.1",
     "rollup": "^3.2.4",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,47 @@
-import { describe, it, expect } from 'vitest';
+import { test, describe, it, expect } from 'vitest';
 import { toKML, foldersToKML } from '../lib/index';
+import { kml } from '@tmcw/togeojson';
+import { DOMParser } from '@xmldom/xmldom';
+
+test('GroundOverlay', () => {
+  const gj = kml(
+    new DOMParser().parseFromString(`<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Folder>
+    <name>Ground Overlays</name>
+    <description>Examples of ground overlays</description>
+    <GroundOverlay>
+      <name>Large-scale overlay on terrain</name>
+      <description>Overlay shows Mount Etna erupting
+          on July 13th, 2001.</description>
+      <Icon>
+        <href>https://tmcw-drop.s3-us-west-1.amazonaws.com/etna%20(1).jpg</href>
+      </Icon>
+      <LatLonBox>
+        <north>37.91904192681665</north>
+        <south>37.46543388598137</south>
+        <east>15.35832653742206</east>
+        <west>14.60128369746704</west>
+        <rotation>-0.1556640799496235</rotation>
+      </LatLonBox>
+    </GroundOverlay>
+  </Folder>
+</kml>`)
+  );
+
+  expect(toKML(gj)).toMatchInlineSnapshot(`
+    "<kml xmlns=\\"http://www.opengis.net/kml/2.2\\"><Document>
+    <GroundOverlay>
+    <name>Large-scale overlay on terrain</name><description>Overlay shows Mount Etna erupting
+              on July 13th, 2001.</description><icon>https://tmcw-drop.s3-us-west-1.amazonaws.com/etna%20(1).jpg</icon><ExtendedData>
+      <Data name=\\"@geometry-type\\"><value>groundoverlay</value></Data></ExtendedData>
+      <gx:LatLonQuad>14.600668902543442,37.91801270483731
+    15.35770894852841,37.92006947469352
+    15.358941332345658,37.466463107960706
+    14.60190128636069,37.464406338104496
+    14.600668902543442,37.91801270483731</gx:LatLonQuad></GroundOverlay></Document></kml>"
+  `);
+});
 
 describe('foldersToKML', () => {
   it('#foldersToKML', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,6 +176,11 @@
   dependencies:
     "@types/unist" "*"
 
+"@xmldom/xmldom@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.5.tgz#7f4b797cfda39355b512b4cfcc66b49b5d93d5f3"
+  integrity sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ==
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
Convert groundoverlays back from geojson (togeojson style) into KML.

TODO:

- [ ] Limit the coordinates output in the ring
- [ ] Documentation
- [ ] Tests